### PR TITLE
Auto Refresh Support Bundle Logs

### DIFF
--- a/cloud/infrastructure/integration-tools/build.gradle.kts
+++ b/cloud/infrastructure/integration-tools/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-val ktor_version = "1.3.1"
+val ktor_version = "1.5.4"
 
 dependencies {
     implementation(kotlin("stdlib"))

--- a/cloud/infrastructure/integration-tools/src/main/resources/static/script.js
+++ b/cloud/infrastructure/integration-tools/src/main/resources/static/script.js
@@ -27,10 +27,7 @@ function Welcome(props) {
         };
 
         fetch('/processing', requestOptions)
-        let redirectionFunction = () => {
-            window.location.href = "/processing/" + data.aggregationUnit
-        };
-        setTimeout(redirectionFunction, 1000)
+        window.location.href = "/processing/" + data.aggregationUnit
     }
 
     return (


### PR DESCRIPTION
Make the web page that updates the progress of processing of support bundle logs to refresh automatically and scroll down to the bottom of the page to show the latest updates.