### PR TITLE
Updated Corfudb version to 0.3.1-SNAPSHOT

### DIFF
--- a/benchmarks/src/jmh/java/org/corfudb/benchmarks/cluster/ClusterBenchmark.java
+++ b/benchmarks/src/jmh/java/org/corfudb/benchmarks/cluster/ClusterBenchmark.java
@@ -192,7 +192,7 @@ public class ClusterBenchmark {
             //https://docs.gradle.org/current/dsl/org.gradle.api.tasks.SourceSetOutput.html
 
             //return new UniverseAppUtil().getAppVersion();
-            return "0.3.0-SNAPSHOT";
+            return "0.3.1-SNAPSHOT";
         }
     }
 }

--- a/benchmarks/src/main/java/org/corfudb/benchmarks/runtime/collections/experiment/rocksdb/RocksDbMap.java
+++ b/benchmarks/src/main/java/org/corfudb/benchmarks/runtime/collections/experiment/rocksdb/RocksDbMap.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
-import org.corfudb.protocols.wireprotocol.ICorfuPayload;
+import org.corfudb.protocols.CorfuProtocolCommon;
 import org.rocksdb.Options;
 import org.rocksdb.PlainTableConfig;
 import org.rocksdb.RocksDB;
@@ -130,7 +130,7 @@ public class RocksDbMap<K, V> implements Map<K, V> {
             iter.seekToFirst();
 
             while (iter.isValid()) {
-                if (value.equals(ICorfuPayload.fromBuffer(iter.value(), valueType))) {
+                if (value.equals(CorfuProtocolCommon.fromBuffer(iter.value(), valueType))) {
                     return true;
                 }
                 iter.next();
@@ -146,7 +146,7 @@ public class RocksDbMap<K, V> implements Map<K, V> {
             if (value == null) {
                 return null;
             }
-            return ICorfuPayload.fromBuffer(value, valueType);
+            return CorfuProtocolCommon.fromBuffer(value, valueType);
         } catch (RocksDBException e) {
             throw new IllegalStateException("can't put data", e);
         }
@@ -169,7 +169,7 @@ public class RocksDbMap<K, V> implements Map<K, V> {
             byte[] serializedKey = serialize(key);
             byte[] value = db.get(serializedKey);
             db.delete(serializedKey);
-            return ICorfuPayload.fromBuffer(value, valueType);
+            return CorfuProtocolCommon.fromBuffer(value, valueType);
         } catch (RocksDBException e) {
             throw new IllegalStateException("Error", e);
         }
@@ -183,7 +183,7 @@ public class RocksDbMap<K, V> implements Map<K, V> {
      */
     public byte[] serialize(Object key) {
         ByteBuf buffer = Unpooled.buffer();
-        ICorfuPayload.serialize(buffer, key);
+        CorfuProtocolCommon.serialize(buffer, key);
         return buffer.array();
     }
 
@@ -209,7 +209,7 @@ public class RocksDbMap<K, V> implements Map<K, V> {
 
             Set<K> keySet = new HashSet<>();
             while (iter.isValid()) {
-                keySet.add(ICorfuPayload.fromBuffer(iter.key(), keyType));
+                keySet.add(CorfuProtocolCommon.fromBuffer(iter.key(), keyType));
                 iter.next();
             }
 
@@ -224,7 +224,7 @@ public class RocksDbMap<K, V> implements Map<K, V> {
         try (RocksIterator iter = db.newIterator()) {
             iter.seekToFirst();
             while (iter.isValid()) {
-                V value = ICorfuPayload.fromBuffer(iter.value(), valueType);
+                V value = CorfuProtocolCommon.fromBuffer(iter.value(), valueType);
                 result.add(value);
                 iter.next();
             }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ configurations.all {
 
 ext {
     logbackVersion = "1.2.3"
-    corfuVersion = "0.3.0-SNAPSHOT"
+    corfuVersion = "0.3.1-SNAPSHOT"
     protobufVersion = "3.11.1"
     nettyVersion = "2.0.25.Final"
     assertjVersion = "3.14.0"

--- a/tests/src/main/resources/universe-tests.properties
+++ b/tests/src/main/resources/universe-tests.properties
@@ -1,5 +1,5 @@
 corfu.cluster.name=static_cluster
 corfu.server.jar=build
 corfu.server.initialPort=9000
-server.version=0.3.0-SNAPSHOT
+server.version=0.3.1-SNAPSHOT
 test.data.clean=true

--- a/universe/docker/Dockerfile
+++ b/universe/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM corfudb/corfu-server:0.3.0-SNAPSHOT
+FROM corfudb/corfu-server:0.3.1-SNAPSHOT
 
 RUN apk update && apk add openssh openssl openrc
 


### PR DESCRIPTION
The Corfu version used in the repo was the old version (0.3.0-SNAPSHOT).
Hence Updated it to use the latest version i.e  0.3.1-SNAPSHOT.
