### PR TITLE
Stop getting artifacts from JFrog

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,15 @@ repositories {
     mavenCentral()
 
     maven {
-        url = 'https://corfudbcloud.jfrog.io/artifactory/corfu-cloud/'
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/corfudb/corfudb")
+        // Temporarily set, will change to a more generic username when get a chance
+        credentials {
+            username = 'xcchang'
+            // This password is a read only access token for resolving this issue:
+            // https://github.community/t/download-from-github-package-registry-without-authentication/14407/122
+            password = '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'
+        }
     }
 }
 


### PR DESCRIPTION
We already exceed the amount of data usage for JFrog free tier. This commit will let corfudb-cloud use Github Packages. Note: the username and access token are temporarily set, and will be changed when we get a more generic username.