### PR TITLE
Increase retries in ClientParam to make tests robust

### DIFF
--- a/universe/universe-core/src/main/java/org/corfudb/universe/universe/node/client/ClientParams.java
+++ b/universe/universe-core/src/main/java/org/corfudb/universe/universe/node/client/ClientParams.java
@@ -35,7 +35,7 @@ public class ClientParams implements NodeParams {
      */
     @Default
     @EqualsAndHashCode.Exclude
-    private final int numRetry = 5;
+    private final int numRetry = 10;
 
     /**
      * Total time to wait before the workflow times out


### PR DESCRIPTION
I noticed some tests intermittently failed because the workflow consumes all the retries. Normally they could pass again when re-run the tests. So it might be good to increase the number of retries to make the tests more robust.