### PR TITLE
Make Docker exception throw to avoid false positive

### DIFF
--- a/.github/workflows/pull_request_universe.yml
+++ b/.github/workflows/pull_request_universe.yml
@@ -11,6 +11,11 @@ jobs:
   test:
     name: Universe Framework unit tests
     runs-on: ubuntu-latest
+
+    env:
+      PKG_USERNAME: ${{ secrets.pkg_username }}
+      PUBLISH_TOKEN: ${{ secrets.publish_token }}
+
     steps:
     - uses: actions/checkout@v2
 

--- a/universe/universe-core/src/main/java/org/corfudb/universe/api/UniverseManager.java
+++ b/universe/universe-core/src/main/java/org/corfudb/universe/api/UniverseManager.java
@@ -46,8 +46,6 @@ public class UniverseManager {
         wf.init();
         try {
             action.accept(wf);
-        } catch (Exception ex) {
-            log.error("Universe error", ex);
         } finally {
             wf.getUniverse().shutdown();
         }


### PR DESCRIPTION
Docker related tests will falsely pass when Docker is just unavailable in the system, because the exception was caught and never thrown.