### PR TITLE
Fix NodeUpAndPartitioned test

### DIFF
--- a/tests/src/test/java/org/corfudb/test/spec/NodeUpAndPartitionedSpec.java
+++ b/tests/src/test/java/org/corfudb/test/spec/NodeUpAndPartitionedSpec.java
@@ -180,7 +180,6 @@ public class NodeUpAndPartitionedSpec {
         // Reconnect the disconnected server
         log.info("**** Reconnect server0 ****");
         server0.reconnect(Arrays.asList(server1, server2));
-        waitForNextEpoch(corfuClient, currEpoch + 1);
         // Verify cluster status is STABLE
         log.info("**** Verify cluster status :: after pausing and disconnecting node ****");
         waitForClusterStatusStable(corfuClient);


### PR DESCRIPTION
`waitForNextEpoch(corfuClient, currEpoch + 1)` sometimes can fail due to the epoch changing more than once during the recovery. What's important here is the next condition - `waitForClusterStatusStable(corfuClient)`