### PR TITLE
Enable Server Side Corfu Compactor

### DIFF
--- a/cloud/corfu/corfu/config/compactor-logback.prod.xml
+++ b/cloud/corfu/corfu/config/compactor-logback.prod.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <property name="LOG_DIRECTORY" value="/var/log/corfu" />
+
+    <appender name="metrics_file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIRECTORY}/corfu-compactor-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${LOG_DIRECTORY}/corfu-compactor-metrics.%i.log.gz</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>25MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+    <appender name="syslog" class="ch.qos.logback.classic.net.SyslogAppender">
+        <syslogHost>localhost</syslogHost>
+        <facility>LOCAL6</facility>
+        <suffixPattern>[%thread] %-5level %msg%n%xException</suffixPattern>
+    </appender>
+    <!-- https://logback.qos.ch/manual/appenders.html#AsyncAppender -->
+    <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="syslog" />
+        <queueSize>1024</queueSize>
+        <maxFlushTime>5000</maxFlushTime>
+    </appender>
+    <appender name="async_metrics_file" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="metrics_file" />
+        <queueSize>1024</queueSize>
+        <maxFlushTime>5000</maxFlushTime>
+    </appender>
+    <root level="info">
+        <appender-ref ref="async_file"/>
+    </root>
+    <logger additivity="false" level="debug" name="org.corfudb.client.metricsdata">
+        <appender-ref ref="async_metrics_file"/>
+    </logger>
+    <logger name="org.corfudb.metricsdata" level="off" />
+
+</configuration>

--- a/cloud/corfu/corfu/config/corfu-compactor-config.yml
+++ b/cloud/corfu/corfu/config/corfu-compactor-config.yml
@@ -1,0 +1,26 @@
+GCParameters:
+  UseConcMarkSweepGC: yes
+  PrintGCDetails: yes
+  PrintGCTimeStamps: yes
+  PrintGCDateStamps: yes
+  Logpath: /var/log/corfu/compactor-gc.log
+  UseGCLogFileRotation: yes
+  NumberOfGCLogFiles: 10
+  GCLogFileSize: 1M
+
+ConfigFiles:
+  CompactorLogPath: /usr/share/corfu/conf/compactor-logback.prod.xml
+  TempDir: /image/corfu-tools/temp
+  ClassPath: /usr/share/corfu/lib/corfudb-tools*jar
+  HeapDumpPath: /image/core/compactor_oom.hprof
+
+CorfuPaths:
+  CorfuMemLogPrefix: /dev/shm/corfu.jvm.gc.
+  CorfuDiskLogDir: /var/log/corfu/jvm
+
+Security:
+  Keystore: /certs/keystore.jks
+  KsPassword: /password/password
+  Truststore: /certs/truststore.jks
+  TruststorePassword: /password/password
+

--- a/cloud/corfu/corfu/templates/statefulset.yaml
+++ b/cloud/corfu/corfu/templates/statefulset.yaml
@@ -56,6 +56,9 @@ spec:
               -k {{ .Values.extraServerArgs.sequencerCacheSize }} \
               -d {{ .Values.extraServerArgs.logLevel }} \
               --log-size-quota-percentage {{ .Values.extraServerArgs.logSizeQuotaPercentage }} \
+              --compactor-script {{ .Values.extraServerArgs.compactorScript }} \
+              --compactor-config {{ .Values.extraServerArgs.compactorConfig }} \
+              --compaction-trigger-freq-ms {{ .Values.extraServerArgs.compactorTriggerFreqMs }} \
               {{- if .Values.extraServerArgs.metricsEnabled }}
               --metrics \
               {{- end }}

--- a/cloud/corfu/corfu/values.yaml
+++ b/cloud/corfu/corfu/values.yaml
@@ -49,5 +49,8 @@ extraServerArgs:
   sequencerCacheSize: "5000000"
   logLevel: DEBUG
   logSizeQuotaPercentage: 40
+  compactorScript: "/usr/share/corfu/scripts/compactor_runner.py"
+  compactorConfig: "/usr/share/corfu/conf/corfu-compactor-config.yml"
+  compactorTriggerFreqMs: 900000
   metricsEnabled: true
 


### PR DESCRIPTION
Without server side compaction, corfu will soon run out of disk space.
This PR enables the feature of Server triggered checkpointing.
