### PR TITLE
Reduce unnecessary log lines from compactor

### DIFF
--- a/cloud/corfu/corfu/config/logback.prod.xml
+++ b/cloud/corfu/corfu/config/logback.prod.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="30 seconds">
 
+    <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+        <Marker>NOT_IMPORTANT</Marker>
+        <OnMatch>DENY</OnMatch>
+        <OnMismatch>NEUTRAL</OnMismatch>
+    </turboFilter>
+
     <property name="LOG_DIRECTORY" value="/var/log/corfu" />
     <appender name="std" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
    Due to many of the unnecessary log lines invoked by the compactor the corfu.9000
    log file becomes too chatty and also leads to quick rolling over.
    This fix helps with the above issue - uses markers to mark unimportant logs
    and then filter them out in the logback file.