### PR TITLE
Migrate from CorfuTable to ICorfuTable

### DIFF
--- a/universe/universe-core/src/main/java/org/corfudb/universe/universe/node/client/CorfuClient.java
+++ b/universe/universe-core/src/main/java/org/corfudb/universe/universe/node/client/CorfuClient.java
@@ -1,7 +1,7 @@
 package org.corfudb.universe.universe.node.client;
 
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.ICorfuTable;
 import org.corfudb.runtime.exceptions.UnreachableClusterException;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutView;
@@ -28,7 +28,7 @@ public interface CorfuClient extends Node<ClientParams> {
      * @param streamName stream name of the table
      * @return CorfuTable object created by runtime
      */
-    <K, V> CorfuTable<K, V> createDefaultCorfuTable(String streamName);
+    <K, V> ICorfuTable<K, V> createDefaultCorfuTable(String streamName);
 
     /**
      * See {@link CorfuRuntime#connect()}

--- a/universe/universe-core/src/main/java/org/corfudb/universe/universe/node/client/LocalCorfuClient.java
+++ b/universe/universe-core/src/main/java/org/corfudb/universe/universe/node/client/LocalCorfuClient.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters.CorfuRuntimeParametersBuilder;
-import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.ICorfuTable;
+import org.corfudb.runtime.collections.PersistentCorfuTable;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.ManagementView;
 import org.corfudb.runtime.view.ObjectsView;
@@ -101,10 +102,10 @@ public class LocalCorfuClient implements CorfuClient {
     }
 
     @Override
-    public <K, V> CorfuTable<K, V> createDefaultCorfuTable(String streamName) {
+    public <K, V> ICorfuTable<K, V> createDefaultCorfuTable(String streamName) {
         return runtime.getObjectsView()
                 .build()
-                .setTypeToken(new TypeToken<CorfuTable<K, V>>() {
+                .setTypeToken(new TypeToken<PersistentCorfuTable<K, V>>() {
                 })
                 .setStreamName(streamName)
                 .open();


### PR DESCRIPTION
The concrete implementation of CorfuTable no longer exists, and it needs to be replaced with ICorfuTable/PersistentCorfuTable.